### PR TITLE
Fix exit code when diff text has no added lines

### DIFF
--- a/src/Runner.php
+++ b/src/Runner.php
@@ -9,7 +9,7 @@ class Runner
 {
     use Logger\StderrLoggerTrait;
 
-    public const EXIT_CODE_INVALID_ARGUMENTS = 3;
+    public const EXIT_CODE_NO_ERRORS_FOUND = 0;
 
     /**
      * Runs PHPCS and then filters out unmodified lines.
@@ -41,8 +41,8 @@ class Runner
         $diffs = $parser->parseDiffOnlyAddedLines($this->readFromStdin());
 
         if (sizeof($diffs) === 0) {
-            $this->logger->error('No diff text found');
-            return self::EXIT_CODE_INVALID_ARGUMENTS;
+            $this->logger->info('No added lines found');
+            return self::EXIT_CODE_NO_ERRORS_FOUND;
         }
         // Appending modified file names to argv
         foreach (array_keys($diffs) as $filename) {

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -10,6 +10,8 @@ class Runner
     use Logger\StderrLoggerTrait;
 
     public const EXIT_CODE_NO_ERRORS_FOUND = 0;
+    public const EXIT_CODE_ERRORS_FOUND_NOT_FIXABLE = 1;
+    public const EXIT_CODE_ERRORS_FOUND_FIXABLE_BY_PHPCBF = 2;
 
     /**
      * Runs PHPCS and then filters out unmodified lines.
@@ -65,7 +67,11 @@ class Runner
         // 0: No errors found.
         // 1: Errors found, but none of them can be fixed by PHPCBF.
         // 2: Errors found, and some can be fixed by PHPCBF.
-        if ($exitCode !== 0 && $exitCode !== 1 && $exitCode !== 2) {
+        if (
+            $exitCode !== self::EXIT_CODE_NO_ERRORS_FOUND &&
+            $exitCode !== self::EXIT_CODE_ERRORS_FOUND_NOT_FIXABLE &&
+            $exitCode !== self::EXIT_CODE_ERRORS_FOUND_FIXABLE_BY_PHPCBF
+        ) {
             echo $result;
             // Returns original exit code.
             return $exitCode;


### PR DESCRIPTION
## issue
- closes #3 

## test

```
% git diff
diff --git a/tests/RunnerTest.php b/tests/RunnerTest.php
index 38c20b4..b3d8121 100644
--- a/tests/RunnerTest.php
+++ b/tests/RunnerTest.php
@@ -24,11 +24,6 @@ class RunnerTest extends TestCase
         };
     }

-    public function testMatchesIgnoringArgs1(): void
-    {
-        $this->assertTrue($this->runner->callMatchesIgnoringArgs('-'));
-    }
-
     public function testMatchesIgnoringArgs2(): void
     {
         $this->assertTrue($this->runner->callMatchesIgnoringArgs('-a'));
% git diff | ./bin/phpcs-added-lines --basepath=$HOME/phpcs-added-lines --standard=PSR12
% echo $?
0
```

```
% git diff
diff --git a/tests/RunnerTest.php b/tests/RunnerTest.php
index 38c20b4..ea432f2 100644
--- a/tests/RunnerTest.php
+++ b/tests/RunnerTest.php
@@ -24,13 +24,7 @@ class RunnerTest extends TestCase
         };
     }

-    public function testMatchesIgnoringArgs1(): void
-    {
-        $this->assertTrue($this->runner->callMatchesIgnoringArgs('-'));
-    }
-
-    public function testMatchesIgnoringArgs2(): void
-    {
+    public function testMatchesIgnoringArgs2(): void {
         $this->assertTrue($this->runner->callMatchesIgnoringArgs('-a'));
     }

% ./vendor/bin/phpcs --basepath=$HOME/phpcs-added-lines --standard=PSR12 --report=json tests/RunnerTest.php
{"totals":{"errors":1,"warnings":0,"fixable":1},"files":{"tests\/RunnerTest.php":{"errors":1,"warnings":0,"messages":[{"message":"Opening brace should be on a new line","source":"Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine","severity":5,"fixable":true,"type":"ERROR","line":27,"column":54}]}}}
% echo $?
2

% git diff | ./bin/phpcs-added-lines --basepath=$HOME/phpcs-added-lines --standard=PSR12
{"totals":{"errors":1,"warnings":0,"fixable":1},"files":{"tests\/RunnerTest.php":{"errors":1,"warnings":0,"messages":[{"message":"Opening brace should be on a new line","source":"Squiz.Functions.MultiLineFunctionDeclaration.BraceOnSameLine","severity":5,"fixable":true,"type":"ERROR","line":27,"column":54}]}}}
% echo $?
2
```